### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 env:
-- PUPPET_VERSION=2.7.22
+- PUPPET_VERSION=2.7.23
 - PUPPET_VERSION=3.3.2
 notifications:
 email: false
@@ -9,7 +9,7 @@ rvm:
 - 1.8.7
 matrix:
   allow_failures:
-  - env: PUPPET_VERSION=2.7.22
+  - env: PUPPET_VERSION=2.7.23
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,8 @@ task :validate do
   Dir['manifests/**/*.pp'].each do |manifest|
     sh "puppet parser validate --noop #{manifest}"
   end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |lib_file|
-    sh "ruby -c #{lib_file}" unless lib_file =~ /spec\/fixtures/
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 describe 'stdlibfeatures' do
 
+  it { should compile.with_all_deps }
+
   context 'with default options' do
-    it {
-      should include_class('stdlibfeatures')
-    }
+    it { should contain_class('stdlibfeatures') }
   end
 end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
